### PR TITLE
Fix GetActualDate Method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roit/roit-date",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "src/index.ts",
   "scripts": {
@@ -17,6 +17,7 @@
     "@types/node": "^6.0.46",
     "chai": "^4.2.0",
     "mocha": "^6.2.0",
+    "mockdate": "^3.0.5",
     "nyc": "^15.1.0",
     "ts-node": "^8.3.0",
     "typescript": "3.7.4"

--- a/src/date/DateFormat.ts
+++ b/src/date/DateFormat.ts
@@ -45,9 +45,9 @@ export function retrieveDate(date: string, timezone = Timezone.AMERICA_SAO_PAULO
  * @description Returns the actual date, can be parsed by timezone, parses AMERICA_SAO_PAULO by default
  * @returns ISO format date
  */
-export function getActualDate(timezone?: Timezone): (string | null) {
-    const date = new Date().toISOString()
-    return retrieveDate(date, timezone)
+export function getActualDate(timezone = Timezone.AMERICA_SAO_PAULO): (string | null) {
+    let date = new Date().toLocaleString("pt-BR", { timeZone: timezone })
+    return formatDate(date, { ignoreTimezone: true, timezone })
 }
 
 /**

--- a/test/date/DateFormat.spec.ts
+++ b/test/date/DateFormat.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { formatDate, diffDays } from '../../src';
-import { formatComponentDate, retrieveDate, validateDateFormat } from '../../src/date/DateFormat';
+import { formatComponentDate, retrieveDate, validateDateFormat, getActualDate } from '../../src/date/DateFormat';
+import MockDate from 'mockdate'
+
+const date = 1621356874897
+MockDate.set(date)
 
 describe('DateFormat', () => {
    it('Should be able to format dd/mm/yyyy to ISO format', () => {
@@ -153,5 +157,13 @@ describe('DateFormat', () => {
          const result = formatDate(date)
          expect(result).to.be.deep.equal(null)
       })
+   })
+})
+
+describe('getActualDate()', () => {
+   it('Should be able to retrieve an actual date', () => {
+      const response = getActualDate()
+
+      expect(response).to.be.deep.equal(new Date('2021-05-18T16:54:34.000Z').toISOString())
    })
 })


### PR DESCRIPTION
refactor(get-actual-date): ensure getActualDate will return a ISO fomatted date based on timezone

Related to RD-8